### PR TITLE
Split out stdout and stderr in Process

### DIFF
--- a/docs/overview/basics.md
+++ b/docs/overview/basics.md
@@ -68,3 +68,16 @@ command.stream
 ```
 
 The bytes are chunked for performance in the form of `StreamChunk[Throwable, Byte]`
+
+### Access stdout and stderr separately
+
+There are times where you need to process the output of stderr as well.
+
+```scala mdoc:silent
+for {
+  process <- Command("./some-process").run
+  stdout  <- process.stdout.string
+  stderr  <- process.stderr.string
+  // ...
+} yield ()
+```

--- a/src/main/scala/zio/process/Command.scala
+++ b/src/main/scala/zio/process/Command.scala
@@ -61,19 +61,19 @@ sealed trait Command {
    * Runs the command returning the output as a list of lines (default encoding of UTF-8).
    */
   def lines: RIO[Blocking, List[String]] =
-    run.flatMap(_.lines)
+    run.flatMap(_.stdout.lines)
 
   /**
    * Runs the command returning the output as a list of lines with the specified encoding.
    */
   def lines(charset: Charset): RIO[Blocking, List[String]] =
-    run.flatMap(_.lines(charset))
+    run.flatMap(_.stdout.lines(charset))
 
   /**
    * Runs the command returning the output as a stream of lines (default encoding of UTF-8).
    */
   def linesStream: ZStream[Blocking, Throwable, String] =
-    ZStream.fromEffect(run).flatMap(_.linesStream)
+    ZStream.fromEffect(run).flatMap(_.stdout.linesStream)
 
   /**
    * A named alias for `|`
@@ -194,19 +194,19 @@ sealed trait Command {
    * Runs the command returning the entire output as a string (default encoding of UTF-8).
    */
   def string: RIO[Blocking, String] =
-    run.flatMap(_.string)
+    run.flatMap(_.stdout.string)
 
   /**
    * Runs the command returning the entire output as a string with the specified encoding.
    */
   def string(charset: Charset): RIO[Blocking, String] =
-    run.flatMap(_.string(charset))
+    run.flatMap(_.stdout.string(charset))
 
   /**
    * Runs the command returning the output as a chunked stream of bytes.
    */
   def stream: RIO[Blocking, StreamChunk[Throwable, Byte]] =
-    run.map(_.stream)
+    run.map(_.stdout.stream)
 
   /**
    * Set the working directory that will be used when this command will be run.
@@ -262,7 +262,7 @@ object Command {
       Option.empty[File],
       ProcessInput.inherit,
       ProcessOutput.Pipe,
-      ProcessOutput.Inherit,
+      ProcessOutput.Pipe,
       redirectErrorStream = false
     )
 }

--- a/src/main/scala/zio/process/Process.scala
+++ b/src/main/scala/zio/process/Process.scala
@@ -23,7 +23,14 @@ import zio.{ RIO, UIO, ZIO }
 
 final case class Process(private val process: JProcess) {
 
+  /**
+   * Access the standard output stream.
+   */
   val stdout: ProcessStream = ProcessStream(process.getInputStream)
+
+  /**
+   * Access the standard error stream.
+   */
   val stderr: ProcessStream = ProcessStream(process.getErrorStream)
 
   /**

--- a/src/main/scala/zio/process/ProcessStream.scala
+++ b/src/main/scala/zio/process/ProcessStream.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.process
+
+import java.io.{ BufferedReader, ByteArrayOutputStream, InputStream, InputStreamReader }
+import java.nio.charset.{ Charset, StandardCharsets }
+
+import zio.{ RIO, UIO, ZManaged }
+import zio.blocking.{ effectBlockingCancelable, Blocking }
+import zio.stream.{ Stream, StreamChunk, ZSink, ZStream }
+
+import scala.collection.mutable.ArrayBuffer
+
+final case class ProcessStream(private val inputStream: InputStream) {
+
+  /**
+   * Return the output of this process as a list of lines (default encoding of UTF-8).
+   */
+  def lines: RIO[Blocking, List[String]] = lines(StandardCharsets.UTF_8)
+
+  /**
+   * Return the output of this process as a list of lines with the specified encoding.
+   */
+  def lines(charset: Charset): RIO[Blocking, List[String]] =
+    ZManaged.fromAutoCloseable(UIO(new BufferedReader(new InputStreamReader(inputStream, charset)))).use { reader =>
+      effectBlockingCancelable {
+        val lines = new ArrayBuffer[String]
+
+        var line: String = null
+        while ({ line = reader.readLine; line != null }) {
+          lines.append(line)
+        }
+
+        lines.toList
+      }(UIO(reader.close()))
+    }
+
+  /**
+   * Return the output of this process as a stream of lines (default encoding of UTF-8).
+   */
+  def linesStream: ZStream[Blocking, Throwable, String] =
+    stream.chunks
+      .aggregate(ZSink.utf8DecodeChunk)
+      .aggregate(ZSink.splitLines)
+      .mapConcatChunk(identity)
+
+  /**
+   * Return the output of this process as a chunked stream of bytes.
+   */
+  def stream: StreamChunk[Throwable, Byte] =
+    Stream.fromInputStream(inputStream)
+
+  /**
+   * Return the entire output of this process as a string (default encoding of UTF-8).
+   */
+  def string: RIO[Blocking, String] = string(StandardCharsets.UTF_8)
+
+  /**
+   * Return the entire output of this process as a string with the specified encoding.
+   */
+  def string(charset: Charset): RIO[Blocking, String] =
+    ZManaged.fromAutoCloseable(UIO(inputStream)).use_ {
+      effectBlockingCancelable {
+        val buffer = new Array[Byte](4096)
+        val result = new ByteArrayOutputStream
+        var length = 0
+
+        while ({ length = inputStream.read(buffer); length != -1 }) {
+          result.write(buffer, 0, length)
+        }
+
+        new String(result.toByteArray, charset)
+      }(UIO(inputStream.close()))
+    }
+}

--- a/src/test/bash/both-streams-test.sh
+++ b/src/test/bash/both-streams-test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echoerr() { echo "$@" 1>&2; }
+
+echo "stdout1"
+echoerr "stderr1"
+
+echo "stdout2"
+echoerr "stderr2"

--- a/src/test/scala/zio/process/PipedCommandSpec.scala
+++ b/src/test/scala/zio/process/PipedCommandSpec.scala
@@ -40,10 +40,10 @@ object PipedCommandSpec extends ZIOProcessBaseSpec {
       )
     },
     test("stderr delegate to rightmost command") {
-      val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).stderr(ProcessOutput.Pipe)
+      val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).stderr(ProcessOutput.Inherit)
 
       assert(command.flatten.map(_.stderr))(
-        equalTo(Vector(ProcessOutput.Inherit, ProcessOutput.Inherit, ProcessOutput.Pipe))
+        equalTo(Vector(ProcessOutput.Pipe, ProcessOutput.Pipe, ProcessOutput.Inherit))
       )
     },
     test("stdout delegate to rightmost command") {


### PR DESCRIPTION
This PR gives you more direct access to `stderr` as well (prior to this, you needed to access the underlying Java Process object to accomplish that). The zio-process `Process` class now has `stdout` and `stderr` vals which you can access like:

```scala
for {
  process <- Command("./some-process").run
  stdout  <- process.stdout.string // `.stream` `.lines` etc.
  stderr  <- process.stderr.string
  // ...
} yield ()
```

One other thing I did was change stderr's ProcessOutput default from Inherit to Pipe. That way there are no surprises if someone accesses Process.stderr only to find that it's empty.