### PR TITLE
Add CommandError ADT

### DIFF
--- a/src/main/scala/zio/process/Command.scala
+++ b/src/main/scala/zio/process/Command.scala
@@ -72,7 +72,7 @@ sealed trait Command {
   /**
    * Runs the command returning the output as a stream of lines (default encoding of UTF-8).
    */
-  def linesStream: ZStream[Blocking, Throwable, String] =
+  def linesStream: ZStream[Blocking, CommandError, String] =
     ZStream.fromEffect(run).flatMap(_.stdout.linesStream)
 
   /**

--- a/src/main/scala/zio/process/Command.scala
+++ b/src/main/scala/zio/process/Command.scala
@@ -19,9 +19,9 @@ import java.io.File
 import java.lang.ProcessBuilder.Redirect
 import java.nio.charset.Charset
 
+import zio._
 import zio.blocking.Blocking
 import zio.stream.{ ZSink, ZStream }
-import zio.{ IO, RIO, Task, UIO, ZIO }
 
 import scala.jdk.CollectionConverters._
 
@@ -38,7 +38,7 @@ sealed trait Command {
   /**
    * Runs the command returning only the exit code.
    */
-  def exitCode: RIO[Blocking, Int] =
+  def exitCode: ZIO[Blocking, CommandError, ExitCode] =
     run.flatMap(_.exitCode)
 
   /**
@@ -60,13 +60,13 @@ sealed trait Command {
   /**
    * Runs the command returning the output as a list of lines (default encoding of UTF-8).
    */
-  def lines: RIO[Blocking, List[String]] =
+  def lines: ZIO[Blocking, CommandError, List[String]] =
     run.flatMap(_.stdout.lines)
 
   /**
    * Runs the command returning the output as a list of lines with the specified encoding.
    */
-  def lines(charset: Charset): RIO[Blocking, List[String]] =
+  def lines(charset: Charset): ZIO[Blocking, CommandError, List[String]] =
     run.flatMap(_.stdout.lines(charset))
 
   /**
@@ -98,7 +98,7 @@ sealed trait Command {
   /**
    * Start running the command returning a handle to the running process.
    */
-  def run: RIO[Blocking, Process] =
+  def run: ZIO[Blocking, CommandError, Process] =
     this match {
       case c: Command.Standard =>
         for {
@@ -131,6 +131,10 @@ sealed trait Command {
                       }
 
                       Process(builder.start())
+                    }.refineOrDie {
+                      case CommandThrowable.ProgramNotFound(e)  => e
+                      case CommandThrowable.PermissionDenied(e) => e
+                      case CommandThrowable.IOError(e)          => e
                     }
           _ <- c.stdin match {
                 case ProcessInput(None) => ZIO.unit
@@ -149,7 +153,7 @@ sealed trait Command {
         c.flatten match {
           // Technically we're guaranteed to always have 2 elements in the piped case, but `Vector` can't represent this.
           // Let's just handle the impossible cases anyway for completeness.
-          case v if v.isEmpty => IO.fail(new NoSuchElementException("No commands in pipe."))
+          case v if v.isEmpty => ZIO.die(new NoSuchElementException("No commands in pipe."))
           case Vector(head)   => head.run
           case Vector(head, tail @ _*) =>
             for {
@@ -191,20 +195,26 @@ sealed trait Command {
   /**
    * Runs the command returning the entire output as a string (default encoding of UTF-8).
    */
-  def string: RIO[Blocking, String] =
+  def string: ZIO[Blocking, CommandError, String] =
     run.flatMap(_.stdout.string)
 
   /**
    * Runs the command returning the entire output as a string with the specified encoding.
    */
-  def string(charset: Charset): RIO[Blocking, String] =
+  def string(charset: Charset): ZIO[Blocking, CommandError, String] =
     run.flatMap(_.stdout.string(charset))
 
   /**
    * Runs the command returning the output as a chunked stream of bytes.
    */
-  def stream: RIO[Blocking, ZStream[Blocking, Throwable, Byte]] =
+  def stream: ZIO[Blocking, CommandError, ZStream[Blocking, CommandError, Byte]] =
     run.map(_.stdout.stream)
+
+  /**
+   * Runs the command returning only the exit code if zero.
+   */
+  def successfulExitCode: ZIO[Blocking, CommandError, ExitCode] =
+    run.flatMap(_.successfulExitCode)
 
   /**
    * Set the working directory that will be used when this command will be run.

--- a/src/main/scala/zio/process/CommandError.scala
+++ b/src/main/scala/zio/process/CommandError.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.process
+
+import java.io.IOException
+
+import zio.ExitCode
+
+sealed abstract class CommandError(cause: Throwable) extends Exception(cause) with Product with Serializable
+
+object CommandError {
+  final case class ProgramNotFound(cause: IOException)  extends CommandError(cause)
+  final case class PermissionDenied(cause: IOException) extends CommandError(cause)
+  final case class NonZeroErrorCode(exitCode: ExitCode) extends CommandError(null)
+  final case class IOError(cause: IOException)          extends CommandError(cause)
+}
+
+private[process] object CommandThrowable {
+  object ProgramNotFound {
+    def unapply(throwable: Throwable): Option[CommandError.ProgramNotFound] =
+      throwable match {
+        case e: IOException =>
+          val notFoundErrorCode = 2
+          if (e.getMessage.contains(s"error=$notFoundErrorCode,")) {
+            Some(CommandError.ProgramNotFound(e))
+          } else None
+
+        case _ => None
+      }
+  }
+
+  object PermissionDenied {
+    def unapply(throwable: Throwable): Option[CommandError.PermissionDenied] =
+      throwable match {
+        case e: IOException =>
+          val permissionDeniedErrorCode = if (OS.os == OS.Windows) 5 else 13
+          if (e.getMessage.contains(s"error=$permissionDeniedErrorCode,")) Some(CommandError.PermissionDenied(e))
+          else None
+
+        case _ => None
+      }
+  }
+
+  object IOError {
+    def unapply(throwable: Throwable): Option[CommandError.IOError] =
+      throwable match {
+        case e: IOException => Some(CommandError.IOError(e))
+        case _              => None
+      }
+  }
+}

--- a/src/main/scala/zio/process/OS.scala
+++ b/src/main/scala/zio/process/OS.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2020 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.process
+
+import java.util.Locale
+
+private[process] sealed trait OS
+
+private[process] object OS {
+  case object MacOS   extends OS
+  case object Windows extends OS
+  case object Linux   extends OS
+  case object Other   extends OS
+
+  lazy val os: OS = {
+    val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
+
+    if (osName.contains("mac") || osName.contains("darwin"))
+      OS.MacOS
+    else if (osName.contains("win"))
+      OS.Windows
+    else if (osName.contains("nux"))
+      OS.Linux
+    else
+      OS.Other
+  }
+}

--- a/src/main/scala/zio/process/Process.scala
+++ b/src/main/scala/zio/process/Process.scala
@@ -15,11 +15,10 @@
  */
 package zio.process
 
-import java.io._
 import java.lang.{ Process => JProcess }
 
 import zio.blocking._
-import zio.{ RIO, UIO, ZIO }
+import zio.{ ExitCode, UIO, ZIO }
 
 final case class Process(private val process: JProcess) {
 
@@ -36,12 +35,24 @@ final case class Process(private val process: JProcess) {
   /**
    * Access the underlying Java Process wrapped in a blocking ZIO.
    */
-  def execute[T](f: JProcess => T): ZIO[Blocking, IOException, T] =
-    effectBlockingInterrupt(f(process)).refineToOrDie[IOException]
+  def execute[T](f: JProcess => T): ZIO[Blocking, CommandError, T] =
+    effectBlockingInterrupt(f(process)).refineOrDie {
+      case CommandThrowable.IOError(e) => e
+    }
 
   /**
    * Return the exit code of this process.
    */
-  def exitCode: RIO[Blocking, Int] =
-    effectBlockingCancelable(process.waitFor())(UIO(process.destroy()))
+  def exitCode: ZIO[Blocking, CommandError, ExitCode] =
+    effectBlockingCancelable(ExitCode(process.waitFor()))(UIO(process.destroy())).refineOrDie {
+      case CommandThrowable.IOError(e) => e
+    }
+
+  /**
+   * Return the exit code of this process if it is zero. If non-zero, it will fail with `CommandError.NonZeroErrorCode`.
+   */
+  def successfulExitCode: ZIO[Blocking, CommandError, ExitCode] =
+    effectBlockingCancelable(ExitCode(process.waitFor()))(UIO(process.destroy())).refineOrDie {
+      case CommandThrowable.IOError(e) => e: CommandError
+    }.filterOrElse(_ == ExitCode.success)(exitCode => ZIO.fail(CommandError.NonZeroErrorCode(exitCode)))
 }

--- a/src/main/scala/zio/process/ProcessInput.scala
+++ b/src/main/scala/zio/process/ProcessInput.scala
@@ -22,7 +22,7 @@ import zio.Chunk
 import zio.blocking.Blocking
 import zio.stream.{ Stream, ZStream }
 
-final case class ProcessInput(source: Option[ZStream[Blocking, Throwable, Byte]])
+final case class ProcessInput(source: Option[ZStream[Blocking, CommandError, Byte]])
 
 object ProcessInput {
   val inherit: ProcessInput = ProcessInput(None)
@@ -31,12 +31,12 @@ object ProcessInput {
    * Returns a ProcessInput from an array of bytes.
    */
   def fromByteArray(bytes: Array[Byte]): ProcessInput =
-    ProcessInput(Some(Stream.fromInputStream(new ByteArrayInputStream(bytes))))
+    ProcessInput(Some(Stream.fromInputStream(new ByteArrayInputStream(bytes)).mapError(CommandError.IOError)))
 
   /**
    * Returns a ProcessInput from a stream of bytes.
    */
-  def fromStream(stream: ZStream[Blocking, Throwable, Byte]): ProcessInput =
+  def fromStream(stream: ZStream[Blocking, CommandError, Byte]): ProcessInput =
     ProcessInput(Some(stream))
 
   /**

--- a/src/main/scala/zio/process/ProcessStream.scala
+++ b/src/main/scala/zio/process/ProcessStream.scala
@@ -56,7 +56,7 @@ final case class ProcessStream(private val inputStream: InputStream) {
   /**
    * Return the output of this process as a stream of lines (default encoding of UTF-8).
    */
-  def linesStream: ZStream[Blocking, Throwable, String] =
+  def linesStream: ZStream[Blocking, CommandError, String] =
     stream
       .aggregate(ZTransducer.utf8Decode)
       .aggregate(ZTransducer.splitLines)

--- a/src/main/scala/zio/process/ProcessStream.scala
+++ b/src/main/scala/zio/process/ProcessStream.scala
@@ -15,12 +15,12 @@
  */
 package zio.process
 
-import java.io.{ BufferedReader, ByteArrayOutputStream, InputStream, InputStreamReader }
+import java.io._
 import java.nio.charset.{ Charset, StandardCharsets }
 
 import zio.blocking.{ effectBlockingCancelable, Blocking }
 import zio.stream.{ ZStream, ZTransducer }
-import zio.{ RIO, UIO, ZManaged }
+import zio.{ UIO, ZIO, ZManaged }
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -29,24 +29,29 @@ final case class ProcessStream(private val inputStream: InputStream) {
   /**
    * Return the output of this process as a list of lines (default encoding of UTF-8).
    */
-  def lines: RIO[Blocking, List[String]] = lines(StandardCharsets.UTF_8)
+  def lines: ZIO[Blocking, CommandError, List[String]] = lines(StandardCharsets.UTF_8)
 
   /**
    * Return the output of this process as a list of lines with the specified encoding.
    */
-  def lines(charset: Charset): RIO[Blocking, List[String]] =
-    ZManaged.fromAutoCloseable(UIO(new BufferedReader(new InputStreamReader(inputStream, charset)))).use { reader =>
-      effectBlockingCancelable {
-        val lines = new ArrayBuffer[String]
+  def lines(charset: Charset): ZIO[Blocking, CommandError, List[String]] =
+    ZManaged
+      .fromAutoCloseable(UIO(new BufferedReader(new InputStreamReader(inputStream, charset))))
+      .use { reader =>
+        effectBlockingCancelable {
+          val lines = new ArrayBuffer[String]
 
-        var line: String = null
-        while ({ line = reader.readLine; line != null }) {
-          lines.append(line)
-        }
+          var line: String = null
+          while ({ line = reader.readLine; line != null }) {
+            lines.append(line)
+          }
 
-        lines.toList
-      }(UIO(reader.close()))
-    }
+          lines.toList
+        }(UIO(reader.close()))
+      }
+      .refineOrDie {
+        case CommandThrowable.IOError(e) => e
+      }
 
   /**
    * Return the output of this process as a stream of lines (default encoding of UTF-8).
@@ -59,29 +64,34 @@ final case class ProcessStream(private val inputStream: InputStream) {
   /**
    * Return the output of this process as a chunked stream of bytes.
    */
-  def stream: ZStream[Blocking, Throwable, Byte] =
-    ZStream.fromInputStream(inputStream)
+  def stream: ZStream[Blocking, CommandError, Byte] =
+    ZStream.fromInputStream(inputStream).mapError(CommandError.IOError)
 
   /**
    * Return the entire output of this process as a string (default encoding of UTF-8).
    */
-  def string: RIO[Blocking, String] = string(StandardCharsets.UTF_8)
+  def string: ZIO[Blocking, CommandError, String] = string(StandardCharsets.UTF_8)
 
   /**
    * Return the entire output of this process as a string with the specified encoding.
    */
-  def string(charset: Charset): RIO[Blocking, String] =
-    ZManaged.fromAutoCloseable(UIO(inputStream)).use_ {
-      effectBlockingCancelable {
-        val buffer = new Array[Byte](4096)
-        val result = new ByteArrayOutputStream
-        var length = 0
+  def string(charset: Charset): ZIO[Blocking, CommandError, String] =
+    ZManaged
+      .fromAutoCloseable(UIO(inputStream))
+      .use_ {
+        effectBlockingCancelable {
+          val buffer = new Array[Byte](4096)
+          val result = new ByteArrayOutputStream
+          var length = 0
 
-        while ({ length = inputStream.read(buffer); length != -1 }) {
-          result.write(buffer, 0, length)
-        }
+          while ({ length = inputStream.read(buffer); length != -1 }) {
+            result.write(buffer, 0, length)
+          }
 
-        new String(result.toByteArray, charset)
-      }(UIO(inputStream.close()))
-    }
+          new String(result.toByteArray, charset)
+        }(UIO(inputStream.close()))
+      }
+      .refineOrDie {
+        case CommandThrowable.IOError(e) => e
+      }
 }

--- a/src/test/bash/no-permissions.sh
+++ b/src/test/bash/no-permissions.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "this should not run because it doesn't have execute permissions"

--- a/src/test/scala/zio/process/CommandSpec.scala
+++ b/src/test/scala/zio/process/CommandSpec.scala
@@ -113,12 +113,12 @@ object CommandSpec extends ZIOProcessBaseSpec {
     testM("return non-zero exit code in success channel") {
       val zio = Command("ls", "--non-existant-flag").exitCode
 
-      assertM(zio)(equalTo(ExitCode(1)))
+      assertM(zio)(not(equalTo(ExitCode.success)))
     },
     testM("absolve non-zero exit code") {
       val zio = Command("ls", "--non-existant-flag").successfulExitCode
 
-      assertM(zio.run)(fails(equalTo(CommandError.NonZeroErrorCode(ExitCode(1)))))
+      assertM(zio.run)(fails(isSubtype[CommandError.NonZeroErrorCode](anything)))
     },
     testM("permission denied is a typed error") {
       val zio = Command("src/test/bash/no-permissions.sh").string

--- a/src/test/scala/zio/process/CommandSpec.scala
+++ b/src/test/scala/zio/process/CommandSpec.scala
@@ -1,14 +1,14 @@
 package zio.process
 
-import java.io.{ File, IOException }
+import java.io.File
 import java.nio.charset.StandardCharsets
 
-import zio.{ Chunk, ZIO }
 import zio.duration._
 import zio.stream.ZTransducer
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock
+import zio.{ Chunk, ExitCode, ZIO }
 
 // TODO: Add aspects for different OSes? scala.util.Properties.isWin, etc. Also try to make this as OS agnostic as possible in the first place
 object CommandSpec extends ZIOProcessBaseSpec {
@@ -38,10 +38,10 @@ object CommandSpec extends ZIOProcessBaseSpec {
 
       assertM(zio)(equalTo(Chunk("1", "2", "3")))
     },
-    testM("fail trying to run a command that doesn't exit") {
+    testM("fail trying to run a command that doesn't exist") {
       val zio = Command("some-invalid-command", "test").string
 
-      assertM(zio.run)(fails(isSubtype[IOException](anything)))
+      assertM(zio.run)(fails(isSubtype[CommandError.ProgramNotFound](anything)))
     },
     testM("pass environment variables") {
       val zio = Command("bash", "-c", "echo -n \"var = $VAR\"").env(Map("VAR" -> "value")).string
@@ -74,6 +74,13 @@ object CommandSpec extends ZIOProcessBaseSpec {
 
       assertM(zio)(contains("Command.scala"))
     },
+    testM("be able to fallback to a different program using typed error channel") {
+      val zio = Command("custom-echo", "-n", "test").string.catchSome {
+        case CommandError.ProgramNotFound(_) => Command("echo", "-n", "test").string
+      }
+
+      assertM(zio)(equalTo("test"))
+    },
     testM("interrupt a process manually") {
       val zio = for {
         fiber  <- Command("sleep", "20").exitCode.fork
@@ -102,6 +109,21 @@ object CommandSpec extends ZIOProcessBaseSpec {
       } yield (stdout, stderr)
 
       assertM(zio)(equalTo(("stdout1\nstdout2\n", "stderr1\nstderr2\n")))
+    },
+    testM("return non-zero exit code in success channel") {
+      val zio = Command("ls", "--non-existant-flag").exitCode
+
+      assertM(zio)(equalTo(ExitCode(1)))
+    },
+    testM("absolve non-zero exit code") {
+      val zio = Command("ls", "--non-existant-flag").successfulExitCode
+
+      assertM(zio.run)(fails(equalTo(CommandError.NonZeroErrorCode(ExitCode(1)))))
+    },
+    testM("permission denied is a typed error") {
+      val zio = Command("src/test/bash/no-permissions.sh").string
+
+      assertM(zio.run)(fails(isSubtype[CommandError.PermissionDenied](anything)))
     },
     testM("redirectErrorStream should merge stderr into stdout") {
       val zio = for {


### PR DESCRIPTION
Resolves #30

Here's my attempt at adding an error ADT. This was brought up once on the Discord a while back.

I found myself particularly needing `CommandError.ProgramNotFound`. It allows me to do stuff like this:

```scala
Command("some-program-that-may-not-exit").string.catchSome {
  case CommandError.ProgramNotFound(_) => Command("fallback-program").string
}
```

for when I want to fallback to running a different program _only if_ the program was not found, not for any general error.

It's useful to have the library do this because Java's Process puts everything in IOException. This means you can't differentiate between the errors easily if you were to do it yourself. You have to resort to parsing the exception message, which is just awful. What's worse is that the messages are different depending on whether it's Windows or not. I handle that in this PR.

I'm not sure if there are any other potential cases to add to CommandError. I added the ones that I thought were useful and potentially actionable. Here's a full list of what I could capture for reference:
https://mariadb.com/kb/en/operating-system-error-codes/

I don't see much else that's compelling, but let me know if you disagree.

A couple of other things:
- I added `successfulExitCode` so that you can absolve non-zero error codes into the error channel. And I map this to `NonZeroErrorCode`.
- I'm using `zio.ExitCode` instead of `Int` now.