### PR TITLE
Add CommandError.WorkingDirectoryMissing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,6 +407,7 @@ project/plugins/project/
 
 .metals/
 .bloop/
+.bsp/
 project/secret
 
 # mdoc

--- a/src/main/scala/zio/process/Command.scala
+++ b/src/main/scala/zio/process/Command.scala
@@ -102,6 +102,11 @@ sealed trait Command {
     this match {
       case c: Command.Standard =>
         for {
+          _       <- ZIO.foreach_(c.workingDirectory) { workingDirectory =>
+                       ZIO
+                         .fail(CommandError.WorkingDirectoryMissing(workingDirectory))
+                         .unless(workingDirectory.exists())
+                     }
           process <- Task {
                        val builder = new ProcessBuilder(c.command: _*)
                        builder.redirectErrorStream(c.redirectErrorStream)

--- a/src/main/scala/zio/process/CommandError.scala
+++ b/src/main/scala/zio/process/CommandError.scala
@@ -15,17 +15,18 @@
  */
 package zio.process
 
-import java.io.IOException
+import java.io.{ File, IOException }
 
 import zio.ExitCode
 
 sealed abstract class CommandError(cause: Throwable) extends Exception(cause) with Product with Serializable
 
 object CommandError {
-  final case class ProgramNotFound(cause: IOException)  extends CommandError(cause)
-  final case class PermissionDenied(cause: IOException) extends CommandError(cause)
-  final case class NonZeroErrorCode(exitCode: ExitCode) extends CommandError(null)
-  final case class IOError(cause: IOException)          extends CommandError(cause)
+  final case class ProgramNotFound(cause: IOException)             extends CommandError(cause)
+  final case class PermissionDenied(cause: IOException)            extends CommandError(cause)
+  final case class WorkingDirectoryMissing(workingDirectory: File) extends CommandError(null)
+  final case class NonZeroErrorCode(exitCode: ExitCode)            extends CommandError(null)
+  final case class IOError(cause: IOException)                     extends CommandError(cause)
 }
 
 private[process] object CommandThrowable {

--- a/src/test/scala/zio/process/CommandSpec.scala
+++ b/src/test/scala/zio/process/CommandSpec.scala
@@ -111,12 +111,12 @@ object CommandSpec extends ZIOProcessBaseSpec {
       assertM(zio)(equalTo(("stdout1\nstdout2\n", "stderr1\nstderr2\n")))
     },
     testM("return non-zero exit code in success channel") {
-      val zio = Command("ls", "--non-existant-flag").exitCode
+      val zio = Command("ls", "--non-existent-flag").exitCode
 
       assertM(zio)(not(equalTo(ExitCode.success)))
     },
     testM("absolve non-zero exit code") {
-      val zio = Command("ls", "--non-existant-flag").successfulExitCode
+      val zio = Command("ls", "--non-existent-flag").successfulExitCode
 
       assertM(zio.run)(fails(isSubtype[CommandError.NonZeroErrorCode](anything)))
     },
@@ -133,6 +133,11 @@ object CommandSpec extends ZIOProcessBaseSpec {
       } yield (stdout, stderr)
 
       assertM(zio)(equalTo(("stdout1\nstderr1\nstdout2\nstderr2\n", "")))
+    },
+    testM("typed error for non-existent working directory") {
+      val zio = Command("ls").workingDirectory(new File("/some/bad/path")).lines
+
+      assertM(zio.run)(fails(isSubtype[CommandError.WorkingDirectoryMissing](anything)))
     }
   )
 }


### PR DESCRIPTION
With the Java's `Process` if you specify a non-existent working directory it'll throw an `IOException` like:

```
java.io.IOException: Cannot run program "ls" (in directory "/some/bad/working-directory"): error=2, No such file or directory
```

And currently with zio-process that gets mapped to `CommandError.ProgramNotFound` which I find a bit misleading, especially for global commands like `ls`. I think it makes sense to differentiate them since there are times where you'd like to handle the 2 cases differently (which is how I found this in the first place).

@jdegoes Do you think this is a reasonable addition?