### PR TITLE
Use NonEmptyChunk for piped representation

### DIFF
--- a/src/main/scala/zio/process/Command.scala
+++ b/src/main/scala/zio/process/Command.scala
@@ -42,12 +42,12 @@ sealed trait Command {
     run.flatMap(_.exitCode)
 
   /**
-   * Flatten this command to a vector of standard commands.
-   * For the standard case, this simply returns a 1 element vector.
-   * For the piped case, all the commands in the pipe will be extracted out into a Vector from left to right.
+   * Flatten this command to a non-empty chunk of standard commands.
+   * For the standard case, this simply returns a 1 element chunk.
+   * For the piped case, all the commands in the pipe will be extracted out into a chunk from left to right.
    */
-  def flatten: Vector[Command.Standard] = this match {
-    case c: Command.Standard => Vector(c)
+  def flatten: NonEmptyChunk[Command.Standard] = this match {
+    case c: Command.Standard => NonEmptyChunk.single(c)
     case Command.Piped(l, r) => l.flatten ++ r.flatten
   }
 
@@ -151,16 +151,13 @@ sealed trait Command {
 
       case c: Command.Piped =>
         c.flatten match {
-          // Technically we're guaranteed to always have 2 elements in the piped case, but `Vector` can't represent this.
-          // Let's just handle the impossible cases anyway for completeness.
-          case v if v.isEmpty          => ZIO.die(new NoSuchElementException("No commands in pipe."))
-          case Vector(head)            => head.run
-          case Vector(head, tail @ _*) =>
+          case chunk if chunk.length == 1 => chunk.head.run
+          case chunk                      =>
             for {
-              stream <- tail.init.foldLeft(head.stream) { case (s, command) =>
+              stream <- chunk.tail.init.foldLeft(chunk.head.stream) { case (s, command) =>
                           s.flatMap(input => command.stdin(ProcessInput.fromStream(input)).stream)
                         }
-              result <- tail.last.stdin(ProcessInput.fromStream(stream)).run
+              result <- chunk.last.stdin(ProcessInput.fromStream(stream)).run
             } yield result
         }
     }

--- a/src/test/scala/zio/process/PipedCommandSpec.scala
+++ b/src/test/scala/zio/process/PipedCommandSpec.scala
@@ -2,7 +2,7 @@ package zio.process
 
 import java.io.File
 
-import zio.Chunk
+import zio.{ Chunk, NonEmptyChunk }
 import zio.test.Assertion._
 import zio.test._
 
@@ -30,35 +30,35 @@ object PipedCommandSpec extends ZIOProcessBaseSpec {
       val env     = Map("key" -> "value")
       val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).env(env)
 
-      assert(command.flatten.map(_.env))(equalTo(Vector(env, env, env)))
+      assert(command.flatten.map(_.env))(equalTo(NonEmptyChunk(env, env, env)))
     },
     test("workingDirectory delegate to all commands") {
       val workingDirectory = new File("working-directory")
       val command          = (Command("cat") | (Command("sort") | Command("head", "-2"))).workingDirectory(workingDirectory)
 
       assert(command.flatten.map(_.workingDirectory))(
-        equalTo(Vector(Some(workingDirectory), Some(workingDirectory), Some(workingDirectory)))
+        equalTo(NonEmptyChunk(Some(workingDirectory), Some(workingDirectory), Some(workingDirectory)))
       )
     },
     test("stderr delegate to rightmost command") {
       val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).stderr(ProcessOutput.Inherit)
 
       assert(command.flatten.map(_.stderr))(
-        equalTo(Vector(ProcessOutput.Pipe, ProcessOutput.Pipe, ProcessOutput.Inherit))
+        equalTo(NonEmptyChunk(ProcessOutput.Pipe, ProcessOutput.Pipe, ProcessOutput.Inherit))
       )
     },
     test("stdout delegate to rightmost command") {
       val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).stdout(ProcessOutput.Inherit)
 
       assert(command.flatten.map(_.stdout))(
-        equalTo(Vector(ProcessOutput.Pipe, ProcessOutput.Pipe, ProcessOutput.Inherit))
+        equalTo(NonEmptyChunk(ProcessOutput.Pipe, ProcessOutput.Pipe, ProcessOutput.Inherit))
       )
     },
     test("redirectErrorStream delegate to rightmost command") {
       val command = (Command("cat") | (Command("sort") | Command("head", "-2"))).redirectErrorStream(true)
 
       assert(command.flatten.map(_.redirectErrorStream))(
-        equalTo(Vector(false, false, true))
+        equalTo(NonEmptyChunk(false, false, true))
       )
     }
   )


### PR DESCRIPTION
I don't believe `NonEmptyChunk` existed when I first wrote this. Now that it's there, I think it's better to use it. It gets rid of that ugly "should never happen" check.