### PR TITLE
Simplify Command.stream signature

### DIFF
--- a/docs/overview/piping.md
+++ b/docs/overview/piping.md
@@ -13,11 +13,9 @@ import zio.process._
 ### Manually
 
 ```scala mdoc:silent
-for {
-  processes     <- Command("ps", "-ef").stream
-  javaProcesses <- Command("grep", "java").stdin(ProcessInput.fromStream(processes)).stream
-  processIds    <- Command("awk", "{print $2}").stdin(ProcessInput.fromStream(javaProcesses)).lines
-} yield processIds
+val processes = Command("ps", "-ef").stream
+val javaProcesses = Command("grep", "java").stdin(ProcessInput.fromStream(processes)).stream
+val processIds = Command("awk", "{print $2}").stdin(ProcessInput.fromStream(javaProcesses)).lines
 ```
 
 ### Using the pipe operator

--- a/src/test/scala/zio/process/CommandSpec.scala
+++ b/src/test/scala/zio/process/CommandSpec.scala
@@ -28,13 +28,10 @@ object CommandSpec extends ZIOProcessBaseSpec {
       assertM(Command("echo", "-n", "1\n2\n3").linesStream.runCollect)(equalTo(Chunk("1", "2", "3")))
     },
     testM("work with stream directly") {
-      val zio = for {
-        stream <- Command("echo", "-n", "1\n2\n3").stream
-        lines  <- stream
-                    .aggregate(ZTransducer.utf8Decode)
-                    .aggregate(ZTransducer.splitLines)
-                    .runCollect
-      } yield lines
+      val zio = Command("echo", "-n", "1\n2\n3").stream
+        .aggregate(ZTransducer.utf8Decode)
+        .aggregate(ZTransducer.splitLines)
+        .runCollect
 
       assertM(zio)(equalTo(Chunk("1", "2", "3")))
     },
@@ -49,10 +46,8 @@ object CommandSpec extends ZIOProcessBaseSpec {
       assertM(zio)(equalTo("var = value"))
     },
     testM("accept streaming stdin") {
-      val zio = for {
-        stream <- Command("echo", "-n", "a", "b", "c").stream
-        result <- Command("cat").stdin(ProcessInput.fromStream(stream)).string
-      } yield result
+      val stream = Command("echo", "-n", "a", "b", "c").stream
+      val zio    = Command("cat").stdin(ProcessInput.fromStream(stream)).string
 
       assertM(zio)(equalTo("a b c"))
     },


### PR DESCRIPTION
@jdegoes I'm not sure how I only noticed this now, but the signature for `Command#stream` is unwieldy.

It can simply be:

```scala
def stream: ZStream[Blocking, CommandError, Byte]
```

instead of:

```scala
def stream: ZIO[Blocking, CommandError, ZStream[Blocking, CommandError, Byte]]
```