### PR TITLE
Update version in docs

### DIFF
--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -14,10 +14,6 @@ Here's list of contents available:
 
 Include ZIO Process in your project by adding the following to your `build.sbt`:
 
-```scala mdoc:passthrough
-println(s"""```""")
-if (zio.process.BuildInfo.isSnapshot)
-  println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
-println(s"""libraryDependencies += "dev.zio" %% "zio-process" % "${zio.process.BuildInfo.version}"""")
-println(s"""```""")
+```scala
+libraryDependencies += "dev.zio" %% "zio-process" % <version>
 ```


### PR DESCRIPTION
I'm temporarily going with displaying `<version>` in the docs for the version number, because code to print out the current version wasn't working for some reason. It was displaying a 0.0.0 SNAPSHOT version. I don't want to give the impression that this library is pre-release.