### PR TITLE
Upgrade zio-process to use ZIO2-M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ usefulTasks := Seq(
   UsefulTask("", "testOnly *.YourSpec -- -t \"YourLabel\"", "Only runs tests with matching term")
 )
 
-val zioVersion = "2.0.0-M2"
+val zioVersion = "2.0.0-M3"
 
 libraryDependencies ++= Seq(
   "dev.zio"                %% "zio"                     % zioVersion,


### PR DESCRIPTION
zio-process in an app using zio2 M3 doesn't work properly. This updates the dependency of zio2 to M3.