### PR TITLE
Backport `killProcess` bug fix

### DIFF
--- a/src/test/bash/kill-test/sample-parent.sh
+++ b/src/test/bash/kill-test/sample-parent.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 echo $$
-sleep 0.2
 ./sample-child.sh &
 ./sample-child.sh &
 sleep 30

--- a/src/test/scala/zio/process/CommandSpec.scala
+++ b/src/test/scala/zio/process/CommandSpec.scala
@@ -155,7 +155,7 @@ object CommandSpec extends ZIOProcessBaseSpec {
                       toScalaOption(ProcessHandle.of(pid.toLong)).exists(_.isAlive)
                     }
       } yield assertTrue(pidsAlive == Chunk(false, true, true))
-    },
+    } @@ TestAspect.nonFlaky(25),
     testM("killTree also kills child processes") {
       for {
         process <- Command("./sample-parent.sh").workingDirectory(new File("src/test/bash/kill-test")).run
@@ -170,7 +170,7 @@ object CommandSpec extends ZIOProcessBaseSpec {
                       toScalaOption(ProcessHandle.of(pid.toLong)).exists(_.isAlive)
                     }
       } yield assertTrue(pidsAlive == Chunk(false, false, false))
-    },
+    } @@ TestAspect.nonFlaky(25),
     testM("killTreeForcibly also kills child processes") {
       for {
         process <- Command("./sample-parent.sh").workingDirectory(new File("src/test/bash/kill-test")).run
@@ -185,7 +185,7 @@ object CommandSpec extends ZIOProcessBaseSpec {
                       toScalaOption(ProcessHandle.of(pid.toLong)).exists(_.isAlive)
                     }
       } yield assertTrue(pidsAlive == Chunk(false, false, false))
-    }
+    } @@ TestAspect.nonFlaky(25)
   )
 
   private def toScalaOption[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None


### PR DESCRIPTION
This backports the fix from the ZIO 2.0 branch for waiting for descendant processes to be fully destroyed