### PR TITLE
ci: fix+modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,48 +14,46 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-      - name: Setup Java
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: temurin
-          java-version: 17
-          check-latest: true
       - name: Cache scala dependencies
-        uses: coursier/cache-action@v6.4.4
+        uses: coursier/cache-action@v6
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Lint code
         run: sbt check
 
   website:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
-      - name: Setup Java
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: temurin
-          java-version: 17
-          check-latest: true
       - name: Cache scala dependencies
-        uses: coursier/cache-action@v6.4.4
+        uses: coursier/cache-action@v6
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Check Document Generation
         run: sbt docs/compileDocs
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        java: ['17']
+        java: ['11', '17', '21']
         scala: ['2.12.19', '2.13.14', '3.3.3']
         platform: ['JVM', 'Native', 'JS']
     steps:
@@ -63,14 +61,13 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-      - name: Setup Java
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          check-latest: true
       - name: Cache scala dependencies
-        uses: coursier/cache-action@v6.4.4
+        uses: coursier/cache-action@v6
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:${{ matrix.java }}
+          apps: sbt
       - name: Install libuv
         if: matrix.platform == 'Native'
         run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -83,14 +80,14 @@ jobs:
         run: sbt ++${{ matrix.scala }} zioProcess${{ matrix.platform }}/test
 
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [lint, website, test]
     steps:
       - name: Aggregate job outcomes
         run: echo "build succeeded"
 
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [ci]
     if: github.event_name != 'pull_request'
@@ -99,14 +96,13 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-      - name: Setup Java
-        uses: actions/setup-java@v4.0.0
-        with:
-          distribution: temurin
-          java-version: 17
-          check-latest: true
       - name: Cache scala dependencies
-        uses: coursier/cache-action@v6.4.4
+        uses: coursier/cache-action@v6
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Release artifacts
         run: sbt ci-release
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -18,15 +18,16 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Cache scala dependencies
+      uses: coursier/cache-action@v6
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Check if the README file is up to date
       run: sbt  docs/checkReadme
     - name: Check if the site workflow is up to date
@@ -41,17 +42,18 @@ jobs:
     if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Cache scala dependencies
+      uses: coursier/cache-action@v6
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Setup NodeJs
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
         registry-url: https://registry.npmjs.org
@@ -65,16 +67,17 @@ jobs:
     if: ${{ (github.event_name == 'push') || ((github.event_name == 'release') && (github.event.action == 'published')) }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v4.1.1
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Cache scala dependencies
+      uses: coursier/cache-action@v6
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Generate Readme
       run: sbt  docs/generateReadme
     - name: Commit Changes


### PR DESCRIPTION
- Update all jobs to use ubuntu-latest
- Replace Java/Scala setup with coursier
- Expand test matrix to cover JDK 11, 17, and 21
- Standardize on JDK 21 for all non-test jobs