### PR TITLE
Fix CI: JDK errno message format and Scala.js version skew

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("dev.zio"             % "zio-sbt-website"               % "0.4.9")
 addSbtPlugin("org.portable-scala"  % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"    % "sbt-scala-native"              % "0.5.9")
 addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject"      % "1.3.2")
-addSbtPlugin("org.scala-js"        % "sbt-scalajs"                   % "1.20.1")
+addSbtPlugin("org.scala-js"        % "sbt-scalajs"                   % "1.22.0")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "3.0.1"
 

--- a/zio-process/js/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
+++ b/zio-process/js/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
@@ -19,6 +19,6 @@ import scala.scalajs.js
 
 private[process] trait CommandErrorPlatformSpecific {
   type IOException = js.JavaScriptException
-  val notFound         = "ENOENT"
-  val permissionDenied = "EACCES"
+  def isNotFound(message: String): Boolean         = message != null && message.contains("ENOENT")
+  def isPermissionDenied(message: String): Boolean = message != null && message.contains("EACCES")
 }

--- a/zio-process/jvm/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
+++ b/zio-process/jvm/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
@@ -18,7 +18,12 @@ package zio.process
 private[process] trait CommandErrorPlatformSpecific {
   type IOException = java.io.IOException
   private val notFoundErrorCode         = 2
-  val notFound                          = s"error=$notFoundErrorCode,"
   private val permissionDeniedErrorCode = if (OS.os == OS.Windows) 5 else 13
-  val permissionDenied                  = s"error=$permissionDeniedErrorCode,"
+
+  def isNotFound(message: String): Boolean         = hasErrorCode(message, notFoundErrorCode)
+  def isPermissionDenied(message: String): Boolean = hasErrorCode(message, permissionDeniedErrorCode)
+
+  // Older JDKs render the errno as `error=2,`, newer ones as `Exec failed, error: 2 (...)`.
+  private def hasErrorCode(message: String, code: Int): Boolean =
+    message != null && (message.contains(s"error=$code,") || message.contains(s"error: $code ("))
 }

--- a/zio-process/native/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
+++ b/zio-process/native/src/main/scala/zio/process/CommandErrorPlatformSpecific.scala
@@ -18,7 +18,12 @@ package zio.process
 private[process] trait CommandErrorPlatformSpecific {
   type IOException = java.io.IOException
   private val notFoundErrorCode         = 2
-  val notFound                          = s"error=$notFoundErrorCode,"
   private val permissionDeniedErrorCode = if (OS.os == OS.Windows) 5 else 1
-  val permissionDenied                  = s"error=$permissionDeniedErrorCode,"
+
+  def isNotFound(message: String): Boolean         = hasErrorCode(message, notFoundErrorCode)
+  def isPermissionDenied(message: String): Boolean = hasErrorCode(message, permissionDeniedErrorCode)
+
+  // Older JDKs render the errno as `error=2,`, newer ones as `Exec failed, error: 2 (...)`.
+  private def hasErrorCode(message: String, code: Int): Boolean =
+    message != null && (message.contains(s"error=$code,") || message.contains(s"error: $code ("))
 }

--- a/zio-process/shared/src/main/scala/zio/process/CommandError.scala
+++ b/zio-process/shared/src/main/scala/zio/process/CommandError.scala
@@ -35,18 +35,18 @@ private[process] object CommandThrowable extends CommandErrorPlatformSpecific {
 
   def classify(throwable: Throwable): CommandError =
     throwable match {
-      case c: CommandError                                           => c
-      case e: IOException if e.getMessage.contains(notFound)         => CommandError.ProgramNotFound(e)
-      case e: IOException if e.getMessage.contains(permissionDenied) => CommandError.PermissionDenied(e)
-      case e: java.io.IOException                                    => CommandError.IOError(e)
-      case e                                                         => CommandError.Error(e)
+      case c: CommandError                                    => c
+      case e: IOException if isNotFound(e.getMessage)         => CommandError.ProgramNotFound(e)
+      case e: IOException if isPermissionDenied(e.getMessage) => CommandError.PermissionDenied(e)
+      case e: java.io.IOException                             => CommandError.IOError(e)
+      case e                                                  => CommandError.Error(e)
     }
 
   object ProgramNotFound {
     def unapply(throwable: Throwable): Option[CommandError.ProgramNotFound] =
       throwable match {
         case e: IOException =>
-          if (e.getMessage.contains(notFound)) {
+          if (isNotFound(e.getMessage)) {
             Some(CommandError.ProgramNotFound(e))
           } else None
 
@@ -58,7 +58,7 @@ private[process] object CommandThrowable extends CommandErrorPlatformSpecific {
     def unapply(throwable: Throwable): Option[CommandError.PermissionDenied] =
       throwable match {
         case e: IOException =>
-          if (e.getMessage.contains(permissionDenied)) Some(CommandError.PermissionDenied(e))
+          if (isPermissionDenied(e.getMessage)) Some(CommandError.PermissionDenied(e))
           else None
 
         case _ => None


### PR DESCRIPTION
## Summary

CI has been red on `series/2.x` since December 2025. There are two independent causes.

### 1. Scala.js version skew — all 3 JS jobs

`test_scala (17, {2.12,2.13,3.3}.x, JS)` never reach the tests; they fail at linking:

```
org.scalajs.ir.IRVersionNotSupportedException: Failed to deserialize a file compiled with
Scala.js 1.21 (supported up to: 1.20): .../scalajs-library_2.13/1.21.0/scalajs-library_2.13-1.21.0.jar
You may need to upgrade the Scala.js sbt plugin to version 1.21 or later.
```

The Scala.js library resolves to 1.21+ while `sbt-scalajs` was pinned to `1.20.1`. Bumped the plugin to `1.22.0`.

### 2. JDK errno message format change — `test_jvms (21, 2.13.x)`

`CommandErrorPlatformSpecific` classified errors by looking for the literal substring `"error=2,"` in the `IOException` message. Newer JDKs changed that rendering:

| JDK | `ProcessBuilder` message |
|---|---|
| 17 | `Cannot run program "x": error=2, No such file or directory` |
| 25 | `Cannot run program "x": Exec failed, error: 2 (No such file or directory)` |

So `ProgramNotFound` and `PermissionDenied` silently degraded to `IOError`, and these two tests failed:

```
✗ IOError is not an instance of ProgramNotFound
✗ IOError is not an instance of PermissionDenied
```

This matches the CI matrix exactly: JDK 11 ✅, JDK 17 ✅, JDK 21 ❌.

The substring constants are replaced with predicates that match both renderings. This is a real bug for users on recent JDKs, not just a CI problem — the typed error channel silently stopped distinguishing "program not found" from other I/O errors.

## Verification

Run locally against both message formats:

| Check | Result |
|---|---|
| JDK 17 (old format): `sbt check` + `zioProcessJVM/test` | 35 passed, 0 failed |
| JDK 25 (new format): `zioProcessJVM/test` | 35 passed, 0 failed |

CI on JDK 21 reported `33 tests passed, 2 tests failed` — exactly the two tests recovered here.

JS linking now succeeds. The remaining JS test failures I see locally are macOS-specific and reproduce identically with these source changes reverted (only the plugin bump applied), so they are unrelated; JS jobs were green on Ubuntu in the last passing run.
